### PR TITLE
Feat/32  main page current weather section  add

### DIFF
--- a/src/pages/main/MainPage.tsx
+++ b/src/pages/main/MainPage.tsx
@@ -1,0 +1,34 @@
+import { CurrentWeather } from './components/CurrentWeather';
+import {
+  ComponentsGrid,
+  FullWidthCard,
+  MainContainer,
+  PlaceholderCard,
+  RecommendCard,
+} from './styles/MainPageContentStyles';
+
+interface WeatherData {
+  location: string;
+  temperature: number;
+  condition: string;
+}
+export const Mainpage = () => {
+  return (
+    <MainContainer>
+      <ComponentsGrid>
+        {/* 현재 날씨 */}
+        <CurrentWeather />
+
+        <PlaceholderCard>오늘의 3벌 추천 코디</PlaceholderCard>
+
+        <FullWidthCard>시간대별 날씨</FullWidthCard>
+
+        <FullWidthCard>AI 추천 문구</FullWidthCard>
+
+        <RecommendCard>즐겨 찾는 지역</RecommendCard>
+
+        <RecommendCard>즐겨 찾는 지역 의상 추천</RecommendCard>
+      </ComponentsGrid>
+    </MainContainer>
+  );
+};

--- a/src/pages/main/components/CurrentWeather.tsx
+++ b/src/pages/main/components/CurrentWeather.tsx
@@ -1,0 +1,54 @@
+import { Box } from '@mui/material';
+import {
+  CurrentWeatherCardHeader,
+  InfoBox,
+  InfoGroup,
+  InfoLabel,
+  InfoValue,
+  LocationText,
+  Temperature,
+  TemperatureSection,
+  WeatherCard,
+  WeatherCondition,
+  WeatherIcon,
+} from '../styles/MainPageContentStyles';
+
+interface CurrentWeatherProps {
+  location: string;
+  temperature: number;
+  condition: string;
+  precipitation: number; // 강수확률
+  feelsLike: number; // 체감온도
+  onEditLocation?: () => void;
+}
+
+export const CurrentWeather = () => {
+  return (
+    <WeatherCard>
+      <CurrentWeatherCardHeader>
+        <LocationText>location</LocationText>
+      </CurrentWeatherCardHeader>
+      <TemperatureSection>
+        <WeatherIcon>🌍</WeatherIcon>
+        <Box>
+          <Temperature>18 °C</Temperature>
+          <WeatherCondition>맑음</WeatherCondition>
+        </Box>
+      </TemperatureSection>
+      <InfoGroup>
+        <InfoBox>
+          <InfoLabel>기온</InfoLabel>
+          <InfoValue>18 °C</InfoValue>
+        </InfoBox>
+        <InfoBox>
+          <InfoLabel>강수확률</InfoLabel>
+          <InfoValue>5%</InfoValue>
+        </InfoBox>
+        <InfoBox>
+          <InfoLabel>체감온도</InfoLabel>
+          <InfoValue>16 °C</InfoValue>
+        </InfoBox>
+      </InfoGroup>
+    </WeatherCard>
+  );
+};

--- a/src/pages/main/styles/MainPageContentStyles.ts
+++ b/src/pages/main/styles/MainPageContentStyles.ts
@@ -1,0 +1,118 @@
+import { Box, Button, Container, styled, Typography } from '@mui/material';
+
+// MainPage Styles
+export const MainContainer = styled(Container)({
+  paddingTop: '24px',
+  paddingBottom: '24px',
+  minWidth: '90vw',
+});
+
+export const ComponentsGrid = styled(Box)({
+  display: 'grid',
+  gridTemplateColumns: 'repeat(2, 1fr)',
+  gap: '20px',
+  '@media (max-width: 768px)': {
+    gridTemplateColumns: '1fr',
+  },
+});
+export const PlaceholderCard = styled(Box)({
+  backgroundColor: '#ffffff',
+  borderRadius: '16px',
+  padding: '20px',
+  boxShadow: '0 2px 8px rgba(0, 0, 0, 0.1)',
+  minHeight: '200px',
+  display: 'flex',
+  alignItems: 'center',
+  justifyContent: 'center',
+  color: '#CCCCCC',
+  fontSize: '14px',
+});
+export const FullWidthCard = styled(PlaceholderCard)({
+  gridColumn: '1 / -1',
+  minHeight: '120px',
+});
+
+export const RecommendCard = styled(PlaceholderCard)({
+  minHeight: '350px',
+  gridColumn: '1 / -1',
+});
+
+// CurrentWeather Section Styles
+export const WeatherCard = styled(Box)({
+  backgroundColor: '#ffffff',
+  borderRadius: '16px',
+  minHeight: '350px',
+  padding: '20px',
+  boxShadow: '0 2px 8px rgba(0, 0, 0, 0.1)',
+  display: 'flex',
+  flexDirection: 'column',
+  gap: '16px',
+});
+
+export const CurrentWeatherCardHeader = styled(Box)({
+  display: 'flex',
+  justifyContent: 'space-between',
+  alignItems: 'center',
+});
+
+export const LocationText = styled(Typography)({
+  fontSize: '16px',
+  fontWeight: 600,
+  color: '#333333',
+});
+
+export const TemperatureSection = styled(Box)({
+  display: 'flex',
+  alignItems: 'center',
+  gap: '12px',
+});
+
+export const WeatherIcon = styled(Box)({
+  fontSize: '48px',
+  color: '#B0BEC5',
+});
+
+export const Temperature = styled(Typography)({
+  fontSize: '48px',
+  fontWeight: 700,
+  color: '#333333',
+});
+
+export const WeatherCondition = styled(Typography)({
+  fontSize: '18px',
+  paddingLeft: '4px',
+  color: '#666666',
+  textAlign: 'left',
+  marginTop: '0px',
+});
+
+export const InfoGroup = styled(Box)({
+  display: 'flex',
+  gap: '20px',
+  marginTop: '3rem',
+});
+
+export const InfoBox = styled(Box)({
+  backgroundColor: '#5B9EFF',
+  borderRadius: '30px',
+  padding: '12px 20px',
+  flex: 1,
+  display: 'flex',
+  flexDirection: 'column',
+  alignItems: 'center',
+  minHeight: '100px',
+  gap: '4px',
+});
+
+export const InfoLabel = styled(Typography)({
+  fontSize: '16px',
+  color: '#ffffff',
+  fontWeight: 400,
+});
+
+export const InfoValue = styled(Typography)({
+  marginTop: '0.7rem',
+  fontSize: '40px',
+  color: '#ffffff',
+  fontWeight: 600,
+});


### PR DESCRIPTION
<!-- PR제목은 브랜치명과 동일하게 
예시 ) Chore/3 dev env set
-->
## 🔍 관련 이슈<!-- 이 PR과 관련된 이슈를 링크해주세요 -->

Resolves #32 

## 📝 변경 사항<!-- 이 PR에서 어떤 것이 변경되었나요? -->

### ✨ 새로운 기능

>메인 페이지
- 현재 날씨 섹션 추가

### 📚 코드 설명

> 메인페이지
- 각 섹션을 불러오고 데이터를 fetch하는 부모 페이지
> 각 컴포넌트
- 부모로부터 데이터 받은 데이터를 보여주는 카드섹션

### 🐛 버그 수정

- X

### ♻️ 리팩토링

- X

### 📑 기타
-  weather 서비스 붙히면 아이콘 진행할 예정
## 🧪 테스트<!-- 어떤 테스트를 진행했나요? -->


## 📸 스크린샷<!-- UI 변경사항이 있다면 스크린샷을 첨부해주세요 -->
<img width="1902" height="904" alt="image" src="https://github.com/user-attachments/assets/2db9cbaf-917d-4d0e-afde-b717165f0a79" />


## 💬 리뷰 요청사항<!-- 리뷰어가 특별히 확인해주었으면 하는 부분 -->

---

**🙏 감사합니다!**
