### PR TITLE
chore/73 axios 인스턴스 및 요청 인터셉터 생성

### DIFF
--- a/src/axios/instance.ts
+++ b/src/axios/instance.ts
@@ -1,0 +1,11 @@
+import axios from 'axios';
+const instance = axios.create({
+  baseURL: 'http://localhost:5173',
+  timeout: 1000,
+  headers: { 'Content-Type': 'application/json' },
+});
+
+const diaryInstance = axios.create({
+  baseURL: 'http://localhost:5173',
+  timeout: 1000,
+});

--- a/src/axios/interceptors.ts
+++ b/src/axios/interceptors.ts
@@ -1,0 +1,48 @@
+import axios from 'axios';
+
+//- 요청인터셉터(전역에서 동작)
+axios.interceptors.request.use((config) => {
+  // localStorage에서 JWT 토큰을 가져옴
+  const token = localStorage.getItem('jwt');
+
+  if (token) {
+    // 토큰이 존재하면 Authorization 헤더에 추가
+    config.headers.Authorization = `Bearer ${token}`;
+  }
+
+  // 수정된 요청 설정 반환
+  return config;
+});
+
+//- 응답인터셉터(전역에서동작)
+// axios.interceptors.response.use(
+//   (response) => {
+//     // 성공적인 응답은 그대로 반환
+//     return response;
+//   },
+//   async (error) => {
+//     if (error.response && error.response.status === 401) {
+//       // 401(Unauthorized) 상태 코드가 발생하면 Access Token이 만료된 것으로 간주
+
+//       // 새 Access Token 발급 요청 (Refresh Token 사용)
+//       const refreshedToken = await refreshToken(); // refreshToken 함수는 새 Access Token을 서버에서 받아오는 함수
+
+//       // 새로 발급받은 JWT 토큰을 localStorage에 저장
+//       localStorage.setItem('jwt', refreshedToken);
+
+//       // 원래 요청을 복제하여 Authorization 헤더를 새 토큰으로 갱신
+//       const originalRequest = error.config;
+//       originalRequest.headers.Authorization = `Bearer ${refreshedToken}`;
+
+//       // 복제된 요청을 새 Access Token으로 재시도
+//         return axios(originalRequest);
+//       } catch (refreshError) {
+//         // Refresh Token이 만료되었거나, 발급 실패 시 추가 처리
+//         console.error("Token refresh failed. Redirecting to login.");
+//         redirectToLogin(); // 로그인 페이지로 리다이렉션
+//         return Promise.reject(refreshError); // 새로운 에러 반환
+//       }
+//     }
+//     return Promise.reject(error); // 기타 에러는 그대로 반환
+//   }
+// );


### PR DESCRIPTION
<!-- PR제목은 브랜치명과 동일하게 
예시 ) Chore/3 dev env set
-->
## 🔍 관련 이슈<!-- 이 PR과 관련된 이슈를 링크해주세요 -->

Resolves #73 

## 📝 변경 사항<!-- 이 PR에서 어떤 것이 변경되었나요? -->

### ✨ 새로운 기능

- 공통부분은 인스턴스로 만들어둠 
- 다빈님이 사용하는 다이어리 인스턴스는 헤더의 컨텐츠 타입이 달라서 인스턴스를 따로 하나 만들었음 
- 요청과 응답 인터셉터에 대한 헤더토큰 작성하였음 . 이걸 통하여 axios로 접근하는 모든 요청과 응답은 이 코드 하나로 먼저 실행이 된다.  

### 📚 코드 설명

```tsx
const instance = axios.create({
  baseURL: 'http://localhost:5173',
  timeout: 1000,
  headers: { 'Content-Type': 'application/json' },
});
```
- 기본 인스턴스 

```tsx
const diaryInstance = axios.create({
  baseURL: 'http://localhost:5173',
  timeout: 1000,
});
```
- 다빈님이 컨텐츠 타입을 직접 커스텀하여 넣는다고 하셔서 
- 이렇게 비어있는 인스턴스로 두었습니다! 


## 💬 리뷰 요청사항<!-- 리뷰어가 특별히 확인해주었으면 하는 부분 -->
- 인터셉터에 대한 제가 이해하는 부분이 맞는지 궁금해요 

```tsx
axios.interceptors.request.use((config) => {
  // localStorage에서 JWT 토큰을 가져옴
  const token = localStorage.getItem('jwt');

  if (token) {
    // 토큰이 존재하면 Authorization 헤더에 추가
    config.headers.Authorization = `Bearer ${token}`;
  }

  // 수정된 요청 설정 반환
  return config;
});
```
- 인터셉터를 아래와 같이 적용시키게 되면 , axios를 통한 모든 요청이 인터셉터에 의해 가로채져서 선행으로 먼저 실행이 된다. 
- 즉 , 우리가 서버에게 어떤 api요청을 하더라도, 위의 요청 인터셉터가 `먼저 실행`된다.
- 그래서 인터셉터 코드는 요청인터셉터,응답인터셉터 하나만 작성해도 된다? 
- 공통으로 실행이 되기 때문에 ??? 

---

**🙏 감사합니다!**
