### PR TITLE
Feat/116  main img lazy loading  add

### DIFF
--- a/src/features/main/components/OutfitItemIcon.tsx
+++ b/src/features/main/components/OutfitItemIcon.tsx
@@ -1,6 +1,7 @@
 import { Box, Typography } from '@mui/material';
 import { styled } from '@mui/material/styles';
 import { ClothingItem } from '../types/clothing';
+import { useIntersectionObserver } from '../../../hooks/useIntersectionObserver';
 
 const IconContainer = styled(Box)({
   display: 'flex',
@@ -27,9 +28,11 @@ interface OutfitItemIconProps {
   showName?: boolean;
 }
 export const OutfitItemIcon = ({ item, showName = true }: OutfitItemIconProps) => {
+  const refCallback = useIntersectionObserver();
+
   return (
     <IconContainer>
-      <IconImage src={item.icon} alt={item.name} loading='lazy' />
+      <IconImage ref={refCallback} data-src={item.icon} alt={item.name} loading='lazy' />
       {showName && <ItemName>{item.name}</ItemName>}
     </IconContainer>
   );

--- a/src/features/main/components/WeatherIcon.tsx
+++ b/src/features/main/components/WeatherIcon.tsx
@@ -2,6 +2,7 @@
 import { Box } from '@mui/material';
 import { styled } from '@mui/material/styles';
 import { getWeatherIconUrl } from '../../../utils/weatherIcon';
+import { useIntersectionObserver } from '../../../hooks/useIntersectionObserver';
 
 const IconImage = styled('img')<{ size: number }>(({ size }) => ({
   width: `${size}px`,
@@ -28,6 +29,7 @@ export const WeatherIcon = ({
   quality = '2x',
   alt = '날씨 아이콘',
 }: WeatherIconProps) => {
+  const refCallback = useIntersectionObserver();
   const iconUrl = getWeatherIconUrl(iconCode, quality);
 
   if (!iconUrl) {
@@ -36,7 +38,7 @@ export const WeatherIcon = ({
 
   return (
     <IconContainer>
-      <IconImage src={iconUrl} alt={alt} size={size} loading='lazy' />
+      <IconImage ref={refCallback} data-src={iconUrl} alt={alt} size={size} loading='lazy' />
     </IconContainer>
   );
 };

--- a/src/hooks/useIntersectionObserver.ts
+++ b/src/hooks/useIntersectionObserver.ts
@@ -1,0 +1,41 @@
+import { useRef, useCallback } from 'react';
+
+/**
+ * lazy loading을 위한  IntersectionOberserver 훅
+ * usage :: 사용해야 하는 img 태그에 ref={refCallback} 과 data-src 속성 추가
+ * @returns ref 콜백 함수
+ */
+export const useIntersectionObserver = () => {
+  const observerRef = useRef<IntersectionObserver | null>(null);
+
+  const observe = useCallback((el: HTMLImageElement | null) => {
+    if (!el) return;
+
+    if (!observerRef.current) {
+      observerRef.current = new IntersectionObserver(
+        (entries) => {
+          entries.forEach((entry) => {
+            if (entry.isIntersecting) {
+              const img = entry.target as HTMLImageElement;
+              const dataSrc = img.getAttribute('data-src');
+              if (dataSrc) {
+                img.src = dataSrc;
+                img.removeAttribute('data-src');
+                observerRef.current?.unobserve(img);
+              }
+            }
+          });
+        },
+        { threshold: 0.1, rootMargin: '50px 0px' }
+      );
+    }
+
+    const dataSrc = el.getAttribute('data-src');
+    const srcAttr = el.getAttribute('src');
+    if (dataSrc && (!srcAttr || srcAttr === '' || srcAttr.startsWith('data:'))) {
+      observerRef.current.observe(el);
+    }
+  }, []);
+
+  return observe;
+};


### PR DESCRIPTION
<!-- PR제목은 브랜치명과 동일하게 
예시 ) Chore/3 dev env set
-->
## 🔍 관련 이슈<!-- 이 PR과 관련된 이슈를 링크해주세요 -->

Resolves #116 

## 📝 변경 사항<!-- 이 PR에서 어떤 것이 변경되었나요? -->
- 메인에서 바로 보이지 않는 이미지에 대해 lazy loading 적용

### ✨ 새로운 기능

> 이미지 lazy loading 추가
- 의상추천의 의상아이콘
- 시간별 날씨의 날씨 아이콘

### 📚 코드 설명

>useIntersectionObserver
```
export const useIntersectionObserver = () => {
  const observerRef = useRef<IntersectionObserver | null>(null);

  const observe = useCallback((el: HTMLImageElement | null) => {
    if (!el) return;

    if (!observerRef.current) {
      observerRef.current = new IntersectionObserver(
        (entries) => {
          entries.forEach((entry) => {
            if (entry.isIntersecting) {
              const img = entry.target as HTMLImageElement;
              const dataSrc = img.getAttribute('data-src');
              if (dataSrc) {
                img.src = dataSrc;
                img.removeAttribute('data-src');
                observerRef.current?.unobserve(img);
              }
            }
          });
        },
        { threshold: 0.1, rootMargin: '50px 0px' }
      );
    }

    const dataSrc = el.getAttribute('data-src');
    const srcAttr = el.getAttribute('src');
    if (dataSrc && (!srcAttr || srcAttr === '' || srcAttr.startsWith('data:'))) {
      observerRef.current.observe(el);
    }
  }, []);

  return observe;
};
```
ex) WeatherIcon.tsx
```
const refCallback = useIntersectionObserver();
  const iconUrl = getWeatherIconUrl(iconCode, quality);

  if (!iconUrl) {
    return null;
  }

  return (
    <IconContainer>
      <IconImage ref={refCallback} data-src={iconUrl} alt={alt} size={size} loading='lazy' />
    </IconContainer>
```
IntersectionObserver로 사용자의 화면에 나타나는 이미지에 대해 data-src 속성을 src로 변경시킴
사용법 - img 태그가 사용되는 곳에 ref를 useIntersectionObserver의 refCallback으로 넣어주고 해당 img태그의 src속성을 data-src로 변경

1. 초기엔 이미지 태그에 src가 아닌 data-src로 저장 >>> src가 아니므로 이미지가 렌더링 되지 않음
2. 사용자의 화면에 해당 img태그 아이템이 나타날때 data-src > src로 치환 >>> 이미지 태그에 src로 채워지며 그때 렌더링

### 🐛 버그 수정

-

### ♻️ 리팩토링

- `OutfitIcon.tsx`, `WeatherIcon.tsx` : 

### 📑 기타

-

## 🧪 테스트<!-- 어떤 테스트를 진행했나요? -->

- [ ] 시간별예보 동작 확인
- [ ] 의상 없어서 확인 불가(추후 확인)

## 📸 스크린샷<!-- UI 변경사항이 있다면 스크린샷을 첨부해주세요 -->
Init - 
<img width="1411" height="644" alt="image" src="https://github.com/user-attachments/assets/05adc48d-d428-4472-b0a2-f28cc4305d61" />
시간별예보를 넘겼을때 -
<img width="1403" height="588" alt="image" src="https://github.com/user-attachments/assets/dadfdcc4-0712-4988-a03d-431f1db70b2d" />

## 💬 리뷰 요청사항<!-- 리뷰어가 특별히 확인해주었으면 하는 부분 -->

---

**🙏 감사합니다!**
