### PR TITLE
Feature/119  마이페이지 입력폼 반영 업데이트

### DIFF
--- a/src/features/location/components/FavoriteLocationSection.tsx
+++ b/src/features/location/components/FavoriteLocationSection.tsx
@@ -32,12 +32,11 @@ const CardSlot = styled(Box)({
   display: 'flex',
   justifyContent: 'center',
   alignItems: 'center',
-  minHeight: '200px',
 });
 
 const AddButton = styled('button')({
-  width: '100px',
-  height: '100px',
+  width: '60px',
+  height: '60px',
   backgroundColor: '#1E3A8A',
   color: '#FFF',
   fontSize: '48px',
@@ -114,29 +113,51 @@ export default function FavoriteLocationSection() {
 
   if (isLoading) return <div>로딩 중...</div>;
 
-  const slots = Array.from({ length: MAX_FAVORITES }, (_, index) => {
-    const favorite = safeFavorites[index];
+  // const slots = Array.from({ length: MAX_FAVORITES }, (_, index) => {
+  //   const favorite = safeFavorites[index];
 
-    if (favorite?.id) {
-      return (
-        <CardSlot key={favorite.id}>
-          <FavoriteLocationCard
-            favorite={favorite}
-            onAliasUpdate={handleAliasUpdate}
-            onDelete={handleDelete}
-          />
-        </CardSlot>
-      );
-    } else if (index === safeFavorites.length && safeFavorites.length < MAX_FAVORITES) {
-      return (
-        <CardSlot key={`add-${index}`}>
-          <AddButton onClick={handleAddClick}>+</AddButton>
-        </CardSlot>
-      );
-    } else {
-      return <CardSlot key={`empty-${index}`} />;
-    }
-  });
+  //   if (favorite?.id) {
+  //     return (
+  //       <CardSlot key={favorite.id}>
+  //         <FavoriteLocationCard
+  //           favorite={favorite}
+  //           onAliasUpdate={handleAliasUpdate}
+  //           onDelete={handleDelete}
+  //         />
+  //       </CardSlot>
+  //     );
+  //   } else if (index === safeFavorites.length && safeFavorites.length < MAX_FAVORITES) {
+  //     return (
+  //       <CardSlot key={`add-${index}`}>
+  //         <AddButton onClick={handleAddClick}>+</AddButton>
+  //       </CardSlot>
+  //     );
+  //   } else {
+  //     return <CardSlot key={`empty-${index}`} />;
+  //   }
+  // });
+
+  // 기존 MAX_FAVORITES 기반 slots 배열 생성 대신
+  const slots = [
+    // 실제 즐겨찾기 카드들
+    ...safeFavorites.map((favorite) => (
+      <CardSlot key={favorite.id}>
+        <FavoriteLocationCard
+          favorite={favorite}
+          onAliasUpdate={handleAliasUpdate}
+          onDelete={handleDelete}
+        />
+      </CardSlot>
+    )),
+    // 추가 버튼 (3개 미만일 때만)
+    ...(safeFavorites.length < MAX_FAVORITES
+      ? [
+          <CardSlot key='add-button'>
+            <AddButton onClick={handleAddClick}>+</AddButton>
+          </CardSlot>,
+        ]
+      : []),
+  ];
 
   const validFavorites = safeFavorites.filter((f) => f?.id);
 

--- a/src/features/mypage/components/ProfileSection.tsx
+++ b/src/features/mypage/components/ProfileSection.tsx
@@ -13,19 +13,12 @@ import {
   TextField,
   Typography,
 } from '@mui/material';
-import Grid from '@mui/material/Grid';
-import { styled } from '@mui/material/styles';
 import { useState } from 'react';
 import { Controller } from 'react-hook-form';
 import BaseModal from '../../../components/Modal/BaseModal';
 import { useNicknameValidateMutation } from '../../auth/hooks/useNicknameValidateMutation';
 import { useMypageForm } from '../hooks/useMypageForm';
 import { ProfileSectionProps } from '../types/mypage.types';
-
-const FormGrid = styled(Grid)(() => ({
-  display: 'flex',
-  flexDirection: 'column',
-}));
 
 export default function ProfileSection({ isEditMode, onEditModeChange }: ProfileSectionProps) {
   const { form, validationState, updateValidation, resetValidation } = useMypageForm();
@@ -73,38 +66,32 @@ export default function ProfileSection({ isEditMode, onEditModeChange }: Profile
         </Typography>
       </Divider>
 
-      <Stack
-        component='section'
-        direction={{ xs: 'column', md: 'row' }}
-        spacing={{ xs: 1, sm: 2, md: 4 }}
-      >
-        <FormGrid>
+      <BaseModal
+        isOpen={nicknameShowModal}
+        onClose={() => setNicknameShowModal(false)}
+        title='닉네임 중복 확인'
+        subtitle={modalMessage}
+        footer={
+          <Button onClick={() => setNicknameShowModal(false)} variant='contained' type='button'>
+            확인
+          </Button>
+        }
+      />
+
+      <Stack direction={{ xs: 'column', sm: 'row' }} spacing={2} sx={{ width: '100%' }}>
+        <FormControl fullWidth>
           <FormLabel htmlFor='name'>이름</FormLabel>
           <TextField
             {...register('name')}
             autoComplete='name'
             fullWidth
             id='name'
-            name='name'
-            type='name'
-            size='medium'
+            placeholder='홍길동'
             disabled
           />
-        </FormGrid>
+        </FormControl>
 
-        <BaseModal
-          isOpen={nicknameShowModal}
-          onClose={() => setNicknameShowModal(false)}
-          title='닉네임 중복 확인'
-          subtitle={modalMessage}
-          footer={
-            <Button onClick={() => setNicknameShowModal(false)} variant='contained' type='button'>
-              확인
-            </Button>
-          }
-        />
-
-        <FormGrid>
+        <FormControl fullWidth>
           <FormLabel htmlFor='nickname'>닉네임</FormLabel>
           <Stack direction='row' spacing={1}>
             <TextField
@@ -114,11 +101,8 @@ export default function ProfileSection({ isEditMode, onEditModeChange }: Profile
               disabled={!isEditMode}
               id='nickname'
               placeholder='동해번쩍 서해번쩍'
-              name='nickname'
-              type='name'
               fullWidth
-              autoComplete='name'
-              size='medium'
+              color={errors.nickname ? 'error' : 'primary'}
             />
             <Button
               variant='contained'
@@ -131,49 +115,49 @@ export default function ProfileSection({ isEditMode, onEditModeChange }: Profile
               중복확인
             </Button>
           </Stack>
-        </FormGrid>
+        </FormControl>
+      </Stack>
 
-        <FormGrid size={{ xs: 12 }}>
-          <FormLabel>성별</FormLabel>
+      <Stack direction={{ xs: 'column', sm: 'row' }} spacing={2} sx={{ width: '100%' }}>
+        <FormControl sx={{ flex: 1 }}>
+          <FormLabel htmlFor='gender'>성별</FormLabel>
           <Controller
             name='gender'
             control={control}
             render={({ field }) => (
-              <RadioGroup row {...field}>
-                <FormControlLabel
-                  value='W'
-                  label='여성'
-                  control={<Radio disabled={!isEditMode} />}
-                />
+              <RadioGroup {...field} row css={{ justifyContent: 'space-around' }}>
                 <FormControlLabel
                   value='M'
-                  label='남성'
                   control={<Radio disabled={!isEditMode} />}
+                  label='남자'
+                />
+                <FormControlLabel
+                  value='W'
+                  control={<Radio disabled={!isEditMode} />}
+                  label='여자'
                 />
               </RadioGroup>
             )}
           />
-        </FormGrid>
+        </FormControl>
 
-        <FormGrid flex={1}>
-          <FormControl>
-            <FormLabel htmlFor='age_group'>연령대</FormLabel>
-            <Controller
-              name='age_group'
-              control={control}
-              render={({ field }) => (
-                <Select {...field} disabled={!isEditMode} id='age_group'>
-                  <MenuItem value={'10'}>10대</MenuItem>
-                  <MenuItem value={'20'}>20대</MenuItem>
-                  <MenuItem value={'30'}>30대</MenuItem>
-                  <MenuItem value={'40'}>40대</MenuItem>
-                  <MenuItem value={'50'}>50대</MenuItem>
-                  <MenuItem value={'60'}>60대</MenuItem>
-                </Select>
-              )}
-            />
-          </FormControl>
-        </FormGrid>
+        <FormControl sx={{ flex: 1 }}>
+          <FormLabel htmlFor='age_group'>연령대</FormLabel>
+          <Controller
+            name='age_group'
+            control={control}
+            render={({ field }) => (
+              <Select {...field} disabled={!isEditMode} id='age_group'>
+                <MenuItem value={'10'}>10대</MenuItem>
+                <MenuItem value={'20'}>20대</MenuItem>
+                <MenuItem value={'30'}>30대</MenuItem>
+                <MenuItem value={'40'}>40대</MenuItem>
+                <MenuItem value={'50'}>50대</MenuItem>
+                <MenuItem value={'60'}>60대</MenuItem>
+              </Select>
+            )}
+          />
+        </FormControl>
       </Stack>
     </Stack>
   );

--- a/src/features/mypage/components/ProfileSection.tsx
+++ b/src/features/mypage/components/ProfileSection.tsx
@@ -17,11 +17,15 @@ import { useState } from 'react';
 import { Controller } from 'react-hook-form';
 import BaseModal from '../../../components/Modal/BaseModal';
 import { useNicknameValidateMutation } from '../../auth/hooks/useNicknameValidateMutation';
-import { useMypageForm } from '../hooks/useMypageForm';
 import { ProfileSectionProps } from '../types/mypage.types';
 
-export default function ProfileSection({ isEditMode, onEditModeChange }: ProfileSectionProps) {
-  const { form, validationState, updateValidation, resetValidation } = useMypageForm();
+export default function ProfileSection({
+  isEditMode,
+  onEditModeChange,
+  form,
+  validationState,
+  updateValidation,
+}: ProfileSectionProps) {
   const {
     register,
     control,

--- a/src/features/mypage/types/mypage.types.ts
+++ b/src/features/mypage/types/mypage.types.ts
@@ -1,9 +1,15 @@
 // features/mypage/types/mypage.types.ts
 
+import { UseFormReturn } from 'react-hook-form';
+import { MyPageFormData } from '../../auth/types/zodTypes';
+
 // 섹션별 Props 타입
 export interface ProfileSectionProps {
   isEditMode: boolean;
   onEditModeChange: (mode: boolean) => void;
+  form: UseFormReturn<MyPageFormData>;
+  validationState: ValidationState;
+  updateValidation: (key: keyof ValidationState, value: boolean) => void;
 }
 
 export interface EmailSectionProps {

--- a/src/main.tsx
+++ b/src/main.tsx
@@ -34,14 +34,6 @@ const theme = createTheme({
       main: '#1F3A89',
     },
   },
-  components: {
-    MuiTextField: {
-      defaultProps: { size: 'small' },
-    },
-    MuiSelect: {
-      defaultProps: { size: 'small' },
-    },
-  },
 });
 
 enableMocking().then(() => {

--- a/src/main.tsx
+++ b/src/main.tsx
@@ -34,6 +34,14 @@ const theme = createTheme({
       main: '#1F3A89',
     },
   },
+  components: {
+    MuiTextField: {
+      defaultProps: { size: 'small' },
+    },
+    MuiSelect: {
+      defaultProps: { size: 'small' },
+    },
+  },
 });
 
 enableMocking().then(() => {

--- a/src/pages/Mypage.tsx
+++ b/src/pages/Mypage.tsx
@@ -17,7 +17,15 @@ export default function Mypage() {
   const [modalTitle, setModalTitle] = useState('');
   const navigate = useNavigate();
 
-  const { form, handleProfileSubmit, resetValidation, isLoading, error } = useMypageForm();
+  const {
+    form,
+    handleProfileSubmit,
+    resetValidation,
+    validationState,
+    updateValidation,
+    isLoading,
+    error,
+  } = useMypageForm();
 
   // 로딩 중일 때
   if (isLoading) {
@@ -29,33 +37,23 @@ export default function Mypage() {
     return <div>에러 발생</div>;
   }
 
-  const onSubmit = form.handleSubmit(
-    (data) => {
-      console.log('🚀 onSubmit 호출됨');
-      console.log('📋 폼 데이터:', data);
-      handleProfileSubmit(
-        data,
-        () => {
-          setModalTitle('회원정보 수정');
-          setModalMessage('마이페이지 수정 완료');
-          setShowModal(true);
-          setIsEditMode(false);
-        },
-        (message) => {
-          setModalTitle('회원정보 수정 오류');
-          setModalMessage(message);
-          setShowModal(true);
-        }
-      );
-    },
-    (errors) => {
-      console.error('❌ 폼 유효성 검사 실패:', errors);
-      console.log('현재 폼 값:', form.getValues());
-      console.log('에러 상세:', JSON.stringify(errors, null, 2));
-    }
-  );
+  const onSubmit = form.handleSubmit((data) => {
+    handleProfileSubmit(
+      data,
+      () => {
+        setModalTitle('회원정보 수정');
+        setModalMessage('마이페이지 수정 완료');
+        setShowModal(true);
+        setIsEditMode(false);
+      },
+      (message) => {
+        setModalTitle('회원정보 수정 오류');
+        setModalMessage(message);
+        setShowModal(true);
+      }
+    );
+  });
   const handleDelete = () => {
-    console.log('UserDelegte');
     navigate('/signup');
   };
   return (
@@ -131,7 +129,13 @@ export default function Mypage() {
           </Box>
 
           {/* 회원정보 섹션 */}
-          <ProfileSection isEditMode={isEditMode} onEditModeChange={setIsEditMode} />
+          <ProfileSection
+            isEditMode={isEditMode}
+            onEditModeChange={setIsEditMode}
+            form={form}
+            validationState={validationState}
+            updateValidation={updateValidation}
+          />
 
           {/* 이메일 변경 섹션 */}
           <EmailSection isEditMode={isEditMode} />
@@ -160,6 +164,8 @@ export default function Mypage() {
 
         {/* 즐겨찾는 지역 섹션 */}
         <FavoriteLocationSection />
+
+        {/* 회원탈퇴 */}
         <Divider sx={{ my: 4 }} />
         <Stack sx={{ alignItems: 'end' }}>
           <Button

--- a/src/pages/auth/SignUp.tsx
+++ b/src/pages/auth/SignUp.tsx
@@ -189,44 +189,52 @@ export default function SignUp() {
           sx={{ display: 'flex', flexDirection: 'column', gap: 4 }}
           onSubmit={handleSubmit(onSubmit)}
         >
-          <FormControl fullWidth>
-            <FormLabel htmlFor='name'>이름</FormLabel>
-            <TextField
-              {...register('name')}
-              error={!!errors.name}
-              helperText={errors.name?.message}
-              autoComplete='name'
-              fullWidth
-              id='name'
-              placeholder='홍길동'
-              color={errors.name ? 'error' : 'primary'}
-            />
-          </FormControl>
-          <FormControl fullWidth>
-            <FormLabel htmlFor='nickname'>닉네임</FormLabel>
-            <Stack direction='row' spacing={1}>
+          <Stack
+            direction={{ xs: 'column', sm: 'row' }}
+            spacing={2}
+            sx={{
+              width: '100%',
+            }}
+          >
+            <FormControl fullWidth>
+              <FormLabel htmlFor='name'>이름</FormLabel>
               <TextField
-                {...register('nickname')}
-                error={!!errors.nickname}
-                helperText={errors.nickname?.message}
+                {...register('name')}
+                error={!!errors.name}
+                helperText={errors.name?.message}
+                autoComplete='name'
                 fullWidth
-                id='nickname'
-                placeholder='동해번쩍 서해번쩍'
-                color={errors.nickname ? 'error' : 'primary'}
-                disabled={isNicknameValidated} // 추가
+                id='name'
+                placeholder='홍길동'
+                color={errors.name ? 'error' : 'primary'}
               />
-              <Button
-                variant='contained'
-                color='info'
-                onClick={handleNicknameValidate}
-                disabled={isNicknameValidated}
-                type='button'
-                sx={{ minWidth: 'fit-content', whiteSpace: 'nowrap' }}
-              >
-                중복확인
-              </Button>
-            </Stack>
-          </FormControl>
+            </FormControl>
+            <FormControl fullWidth>
+              <FormLabel htmlFor='nickname'>닉네임</FormLabel>
+              <Stack direction='row' spacing={1}>
+                <TextField
+                  {...register('nickname')}
+                  error={!!errors.nickname}
+                  helperText={errors.nickname?.message}
+                  fullWidth
+                  id='nickname'
+                  placeholder='동해번쩍 서해번쩍'
+                  color={errors.nickname ? 'error' : 'primary'}
+                  disabled={isNicknameValidated} // 추가
+                />
+                <Button
+                  variant='contained'
+                  color='info'
+                  onClick={handleNicknameValidate}
+                  disabled={isNicknameValidated}
+                  type='button'
+                  sx={{ minWidth: 'fit-content', whiteSpace: 'nowrap' }}
+                >
+                  중복확인
+                </Button>
+              </Stack>
+            </FormControl>
+          </Stack>
 
           <Stack
             direction={{ xs: 'column', sm: 'row' }}
@@ -269,29 +277,72 @@ export default function SignUp() {
 
           <FormControl>
             <FormLabel htmlFor='email'>이메일</FormLabel>
-            <TextField
-              {...register('email')}
-              disabled={isEmailVerified}
-              fullWidth
-              id='email'
-              placeholder='your@email.com'
-              autoComplete='email'
-              variant='outlined'
-              error={!!errors.email}
-              helperText={errors.email?.message}
-              color={errors.email ? 'error' : 'primary'}
-            />
-            <Button
-              variant='contained'
-              color='success'
-              type='button'
-              onClick={handleEmailValidate}
-              disabled={isEmailVerified}
-            >
-              인증코드 보내기
-            </Button>
+            <Stack direction={{ xs: 'column', sm: 'row' }} spacing={{ xs: 1, sm: 4 }}>
+              <TextField
+                {...register('email')}
+                disabled={isEmailVerified}
+                id='email'
+                placeholder='your@email.com'
+                autoComplete='email'
+                variant='outlined'
+                error={!!errors.email}
+                fullWidth
+                helperText={errors.email?.message}
+                color={errors.email ? 'error' : 'primary'}
+              />
+              <Button
+                variant='contained'
+                color='success'
+                type='button'
+                onClick={handleEmailValidate}
+                disabled={isEmailVerified}
+                sx={{ minWidth: 'fit-content', whiteSpace: 'nowrap' }}
+              >
+                인증확인
+              </Button>
+            </Stack>
           </FormControl>
 
+          <Stack
+            direction={{ xs: 'column', sm: 'row' }}
+            spacing={2}
+            sx={{
+              width: '100%',
+            }}
+          >
+            <FormControl fullWidth>
+              <FormLabel htmlFor='password'>비밀번호</FormLabel>
+              <TextField
+                {...register('password')}
+                error={!!errors.password}
+                helperText={errors.password?.message}
+                required
+                fullWidth
+                placeholder='••••••'
+                type='password'
+                id='password'
+                autoComplete='new-password'
+                variant='outlined'
+                color={errors.password ? 'error' : 'primary'}
+              />
+            </FormControl>
+            <FormControl fullWidth>
+              <FormLabel htmlFor='passwordConfirm'>비밀번호 확인</FormLabel>
+              <TextField
+                {...register('passwordConfirm')}
+                error={!!errors.passwordConfirm}
+                helperText={errors.passwordConfirm?.message}
+                required
+                fullWidth
+                placeholder='••••••'
+                type='password'
+                id='passwordConfirm'
+                autoComplete='new-password'
+                variant='outlined'
+                color={errors.passwordConfirm ? 'error' : 'primary'}
+              />
+            </FormControl>
+          </Stack>
           {isEmailVerified ? (
             <FormControl>
               <FormLabel htmlFor='emailCode'>이메일 인증코드</FormLabel>
@@ -337,38 +388,6 @@ export default function SignUp() {
             }
           />
 
-          <FormControl>
-            <FormLabel htmlFor='password'>비밀번호</FormLabel>
-            <TextField
-              {...register('password')}
-              error={!!errors.password}
-              helperText={errors.password?.message}
-              required
-              fullWidth
-              placeholder='••••••'
-              type='password'
-              id='password'
-              autoComplete='new-password'
-              variant='outlined'
-              color={errors.password ? 'error' : 'primary'}
-            />
-          </FormControl>
-          <FormControl>
-            <FormLabel htmlFor='passwordConfirm'>비밀번호 확인</FormLabel>
-            <TextField
-              {...register('passwordConfirm')} // 이게 name, onChange 등을 자동으로 추가
-              error={!!errors.passwordConfirm}
-              helperText={errors.passwordConfirm?.message}
-              required
-              fullWidth
-              placeholder='••••••'
-              type='password'
-              id='passwordConfirm'
-              autoComplete='new-password'
-              variant='outlined'
-              color={errors.passwordConfirm ? 'error' : 'primary'}
-            />
-          </FormControl>
           <Button
             type='submit'
             fullWidth
@@ -383,15 +402,17 @@ export default function SignUp() {
           <Typography sx={{ color: 'text.secondary' }}>or</Typography>
         </Divider>
         <Box sx={{ display: 'flex', flexDirection: 'column', gap: 2 }}>
-          <GoogleButton fullWidth onClick={() => alert('Sign in with Google')}>
-            구글 로그인
-          </GoogleButton>
-          <KakaoButton fullWidth onClick={() => alert('Sign in with 카카오')}>
-            카카오 로그인
-          </KakaoButton>
-          <NaverButton fullWidth onClick={() => alert('Sign in with 네이버')}>
-            네이버 로그인
-          </NaverButton>
+          <Stack direction={{ xs: 'column', sm: 'row' }} spacing={{ xs: 1, sm: 2, md: 4 }}>
+            <GoogleButton fullWidth onClick={() => alert('Sign in with Google')}>
+              구글 로그인
+            </GoogleButton>
+            <KakaoButton fullWidth onClick={() => alert('Sign in with 카카오')}>
+              카카오 로그인
+            </KakaoButton>
+            <NaverButton fullWidth onClick={() => alert('Sign in with 네이버')}>
+              네이버 로그인
+            </NaverButton>
+          </Stack>
           <Typography sx={{ textAlign: 'center' }}>
             이미 계정이 있으신가요?{' '}
             <Link href='/login' variant='body2' sx={{ alignSelf: 'center' }}>

--- a/src/styles/AuthStyle.tsx
+++ b/src/styles/AuthStyle.tsx
@@ -16,7 +16,7 @@ export const CardMui = styled(MuiCard)(({ theme }) => ({
   boxShadow:
     'hsla(220, 30%, 5%, 0.05) 0px 5px 15px 0px, hsla(220, 25%, 10%, 0.05) 0px 15px 35px -5px',
   [theme.breakpoints.up('md')]: {
-    width: '960px',
+    width: '640px',
   },
 }));
 
@@ -24,6 +24,6 @@ export const ContainerMui = styled(Stack)(({ theme }) => ({
   padding: theme.spacing(2),
   fontFamily: 'Pretendard',
   [theme.breakpoints.up('md')]: {
-    padding: theme.spacing(4),
+    padding: theme.spacing(2),
   },
 }));


### PR DESCRIPTION
<!-- PR제목은 브랜치명과 동일하게 
예시 ) Chore/3 dev env set
-->
## 🔍 관련 이슈<!-- 이 PR과 관련된 이슈를 링크해주세요 -->

Resolves #119

## 🔧 변경 내용 상세

### 1. `mypage.types.ts`

**변경 이유:** ProfileSection이 부모로부터 form 인스턴스를 받도록 타입 정의 추가

**추가된 내용:**
```typescript
import { UseFormReturn } from 'react-hook-form';
import { MyPageFormData } from '../../auth/types/zodTypes';

export interface ProfileSectionProps {
  isEditMode: boolean;
  onEditModeChange: (mode: boolean) => void;
  // ✅ 새로 추가된 props
  form: UseFormReturn<MyPageFormData>;
  validationState: ValidationState;
  updateValidation: (key: keyof ValidationState, value: boolean) => void;
}
```

**영향:**
- ProfileSection 컴포넌트가 부모로부터 form, validationState, updateValidation을 props로 받을 수 있도록 타입 정의

---

### 2. `ProfileSection.tsx`

**변경 이유:** 중복된 form 인스턴스 생성 문제 해결

**Before:**
```typescript
export default function ProfileSection({ isEditMode, onEditModeChange }: ProfileSectionProps) {
  // ❌ 문제: 자체적으로 form 인스턴스 생성 (Mypage와 별개)
  const { form, validationState, updateValidation } = useMypageForm();
```

**After:**
```typescript
export default function ProfileSection({
  isEditMode,
  onEditModeChange,
  form,              // ✅ props로 받음
  validationState,   // ✅ props로 받음
  updateValidation,  // ✅ props로 받음
}: ProfileSectionProps) {
  // useMypageForm() 호출 제거됨 ✅
```

**제거된 import:**
```typescript
- import { useMypageForm } from '../hooks/useMypageForm';
```

**영향:**
- ProfileSection이 더 이상 독립적인 form 인스턴스를 생성하지 않음
- 부모(Mypage)의 form 인스턴스를 공유하여 데이터 동기화 문제 해결

---

### 3. `Mypage.tsx`

**변경 이유:** ProfileSection에 form 관련 props 전달 및 디버깅 로그 제거

**변경 1: useMypageForm에서 추가 값 destructure**
```typescript
// Before
const { form, handleProfileSubmit, resetValidation, isLoading, error } = useMypageForm();

// After
const {
  form,
  handleProfileSubmit,
  resetValidation,
  validationState,   // ✅ 추가
  updateValidation,  // ✅ 추가
  isLoading,
  error,
} = useMypageForm();
```

**변경 2: ProfileSection에 props 전달**
```typescript
// Before
<ProfileSection isEditMode={isEditMode} onEditModeChange={setIsEditMode} />

// After
<ProfileSection
  isEditMode={isEditMode}
  onEditModeChange={setIsEditMode}
  form={form}                          // ✅ 전달
  validationState={validationState}    // ✅ 전달
  updateValidation={updateValidation}  // ✅ 전달
/>
```

**변경 4: onSubmit 핸들러 간소화**
```typescript
// Before
const onSubmit = form.handleSubmit(
  (data) => { /* ... */ },
  (errors) => { /* 에러 로깅 */ }  // ❌ 제거됨
);

// After
const onSubmit = form.handleSubmit((data) => {
  handleProfileSubmit(/* ... */);
});
```

**영향:**
- Mypage와 ProfileSection이 동일한 form 인스턴스를 공유
- 개발용 콘솔 로그 제거로 프로덕션 코드 정리
- 코드 가독성 향상

---

## 🔍 테스트 확인 사항

수정 후 다음 사항들이 정상 동작하는지 확인했습니다:

✅ 마이페이지에서 "수정하기" 버튼 클릭
✅ 성별, 연령대, 닉네임 수정
✅ "수정완료" 버튼 클릭 시 수정된 데이터가 서버로 전송됨
✅ 페이지 새로고침 후에도 수정된 데이터가 유지됨
✅ 콘솔에 디버깅 로그가 더 이상 출력되지 않음

## 📸 스크린샷<!-- UI 변경사항이 있다면 스크린샷을 첨부해주세요 -->
### 수정본
<img width="1464" height="959" alt="스크린샷 2025-11-19 오후 10 35 03" src="https://github.com/user-attachments/assets/03b3c7fb-da0a-47a6-9829-8dabc7874ba5" />

### 새로고침 후 
<img width="1464" height="959" alt="스크린샷 2025-11-19 오후 10 35 28" src="https://github.com/user-attachments/assets/3c12dac3-6145-4dd7-bf9b-ae8c4cb084e6" />

## 💬 리뷰 요청사항<!-- 리뷰어가 특별히 확인해주었으면 하는 부분 -->

---

**🙏 감사합니다!**
