### PR TITLE
Feature/123  폼 데이터 수정 

### DIFF
--- a/src/features/location/components/FavoriteLocationCard.tsx
+++ b/src/features/location/components/FavoriteLocationCard.tsx
@@ -20,9 +20,11 @@ const CardContainer = styled(Box)({
   backgroundColor: '#FFF',
   border: '2px solid #E0E0E0',
   borderRadius: '12px',
-  padding: '16px',
+  padding: '24px',
   cursor: 'grab',
   transition: 'all 0.2s',
+  width: '100%',
+  minHeight: '60px', // 최소 높이 설정
   '&:hover': {
     borderColor: '#1976D2',
     transform: 'translateY(-2px)',

--- a/src/features/location/components/FavoriteLocationSection.tsx
+++ b/src/features/location/components/FavoriteLocationSection.tsx
@@ -32,12 +32,11 @@ const CardSlot = styled(Box)({
   display: 'flex',
   justifyContent: 'center',
   alignItems: 'center',
-  minHeight: '200px',
 });
 
 const AddButton = styled('button')({
-  width: '100px',
-  height: '100px',
+  width: '60px',
+  height: '60px',
   backgroundColor: '#1E3A8A',
   color: '#FFF',
   fontSize: '48px',
@@ -114,29 +113,51 @@ export default function FavoriteLocationSection() {
 
   if (isLoading) return <div>로딩 중...</div>;
 
-  const slots = Array.from({ length: MAX_FAVORITES }, (_, index) => {
-    const favorite = safeFavorites[index];
+  // const slots = Array.from({ length: MAX_FAVORITES }, (_, index) => {
+  //   const favorite = safeFavorites[index];
 
-    if (favorite?.id) {
-      return (
-        <CardSlot key={favorite.id}>
-          <FavoriteLocationCard
-            favorite={favorite}
-            onAliasUpdate={handleAliasUpdate}
-            onDelete={handleDelete}
-          />
-        </CardSlot>
-      );
-    } else if (index === safeFavorites.length && safeFavorites.length < MAX_FAVORITES) {
-      return (
-        <CardSlot key={`add-${index}`}>
-          <AddButton onClick={handleAddClick}>+</AddButton>
-        </CardSlot>
-      );
-    } else {
-      return <CardSlot key={`empty-${index}`} />;
-    }
-  });
+  //   if (favorite?.id) {
+  //     return (
+  //       <CardSlot key={favorite.id}>
+  //         <FavoriteLocationCard
+  //           favorite={favorite}
+  //           onAliasUpdate={handleAliasUpdate}
+  //           onDelete={handleDelete}
+  //         />
+  //       </CardSlot>
+  //     );
+  //   } else if (index === safeFavorites.length && safeFavorites.length < MAX_FAVORITES) {
+  //     return (
+  //       <CardSlot key={`add-${index}`}>
+  //         <AddButton onClick={handleAddClick}>+</AddButton>
+  //       </CardSlot>
+  //     );
+  //   } else {
+  //     return <CardSlot key={`empty-${index}`} />;
+  //   }
+  // });
+
+  // 기존 MAX_FAVORITES 기반 slots 배열 생성 대신
+  const slots = [
+    // 실제 즐겨찾기 카드들
+    ...safeFavorites.map((favorite) => (
+      <CardSlot key={favorite.id}>
+        <FavoriteLocationCard
+          favorite={favorite}
+          onAliasUpdate={handleAliasUpdate}
+          onDelete={handleDelete}
+        />
+      </CardSlot>
+    )),
+    // 추가 버튼 (3개 미만일 때만)
+    ...(safeFavorites.length < MAX_FAVORITES
+      ? [
+          <CardSlot key='add-button'>
+            <AddButton onClick={handleAddClick}>+</AddButton>
+          </CardSlot>,
+        ]
+      : []),
+  ];
 
   const validFavorites = safeFavorites.filter((f) => f?.id);
 

--- a/src/features/location/components/FavoriteLocationSection.tsx
+++ b/src/features/location/components/FavoriteLocationSection.tsx
@@ -7,22 +7,20 @@ import FavoriteRegionModal from '../../../components/Modal/FavoriteRegionModal';
 import { useFavoriteLocations } from '../hooks/useFavoriteLocations';
 import FavoriteLocationCard from './FavoriteLocationCard';
 
-const MAX_FAVORITES = 3;
+const MAX_FAVORITES = 4;
 
 const Container = styled(Box)({
   display: 'flex',
   flexDirection: 'column',
   gap: '16px',
   padding: '16px',
+  width: '100%',
 });
 
 const GridLayout = styled(Box)({
   display: 'grid',
-  gridTemplateColumns: 'repeat(3, 1fr)',
+  gridTemplateColumns: 'repeat(2, 1fr)',
   gap: '24px',
-  '@media (max-width: 1024px)': {
-    gridTemplateColumns: 'repeat(2, 1fr)',
-  },
   '@media (max-width: 768px)': {
     gridTemplateColumns: '1fr',
   },
@@ -57,7 +55,7 @@ const AddButton = styled('button')({
 });
 
 export default function FavoriteLocationSection() {
-  const { favorites, isLoading, deleteFavorite, updateAlias, reorderFavorites } =
+  const { favorites, isLoading, addFavorite, deleteFavorite, updateAlias, reorderFavorites } =
     useFavoriteLocations();
   const [modalOpen, setModalOpen] = useState(false);
 
@@ -107,35 +105,16 @@ export default function FavoriteLocationSection() {
     setModalOpen(false);
   };
 
-  const handleModalSave = () => {
+  const handleModalSave = (data: { city: string; district: string }) => {
+    addFavorite({
+      city: data.city,
+      district: data.district,
+      alias: `${data.city} ${data.district}`, // 기본 alias 설정 (나중에 수정 가능)
+    });
     setModalOpen(false);
   };
 
   if (isLoading) return <div>로딩 중...</div>;
-
-  // const slots = Array.from({ length: MAX_FAVORITES }, (_, index) => {
-  //   const favorite = safeFavorites[index];
-
-  //   if (favorite?.id) {
-  //     return (
-  //       <CardSlot key={favorite.id}>
-  //         <FavoriteLocationCard
-  //           favorite={favorite}
-  //           onAliasUpdate={handleAliasUpdate}
-  //           onDelete={handleDelete}
-  //         />
-  //       </CardSlot>
-  //     );
-  //   } else if (index === safeFavorites.length && safeFavorites.length < MAX_FAVORITES) {
-  //     return (
-  //       <CardSlot key={`add-${index}`}>
-  //         <AddButton onClick={handleAddClick}>+</AddButton>
-  //       </CardSlot>
-  //     );
-  //   } else {
-  //     return <CardSlot key={`empty-${index}`} />;
-  //   }
-  // });
 
   // 기존 MAX_FAVORITES 기반 slots 배열 생성 대신
   const slots = [

--- a/src/features/mypage/components/EmailSection.tsx
+++ b/src/features/mypage/components/EmailSection.tsx
@@ -16,20 +16,24 @@ import {
   useSendEmailCodeMutation,
   useVerifyEmailCodeMutation,
 } from '../../auth/hooks/useEmailVerificationMutation';
-import { useMypageForm } from '../hooks/useMypageForm';
-import { EmailSectionProps } from '../types/mypage.types';
+import { ProfileSectionProps } from '../types/mypage.types';
 
 const FormGrid = styled(Grid)(() => ({
   display: 'flex',
   flexDirection: 'column',
 }));
 
-export default function EmailSection({ isEditMode }: EmailSectionProps) {
-  const { form, validationState, updateValidation } = useMypageForm();
+export default function EmailSection({
+  isEditMode,
+  onEditModeChange,
+  form,
+  validationState,
+  updateValidation,
+}: ProfileSectionProps) {
   const {
     register,
     watch,
-    formState: { errors },
+    formState: { errors, defaultValues },
   } = form;
 
   const sendEmailCode = useSendEmailCodeMutation();
@@ -41,6 +45,15 @@ export default function EmailSection({ isEditMode }: EmailSectionProps) {
 
   const handleEmailValidate = async () => {
     const email = watch('email') as string;
+    const currentEmail = defaultValues?.email as string;
+
+    // 현재 이메일과 동일한지 확인
+    if (email === currentEmail) {
+      setModalTitle('이메일 변경');
+      setModalMessage('현재 사용 중인 이메일과 동일합니다. 새로운 이메일을 입력해주세요.');
+      setShowModal(true);
+      return;
+    }
 
     sendEmailCode.mutate(
       { email },

--- a/src/features/mypage/components/ProfileSection.tsx
+++ b/src/features/mypage/components/ProfileSection.tsx
@@ -13,19 +13,12 @@ import {
   TextField,
   Typography,
 } from '@mui/material';
-import Grid from '@mui/material/Grid';
-import { styled } from '@mui/material/styles';
 import { useState } from 'react';
 import { Controller } from 'react-hook-form';
 import BaseModal from '../../../components/Modal/BaseModal';
 import { useNicknameValidateMutation } from '../../auth/hooks/useNicknameValidateMutation';
 import { useMypageForm } from '../hooks/useMypageForm';
 import { ProfileSectionProps } from '../types/mypage.types';
-
-const FormGrid = styled(Grid)(() => ({
-  display: 'flex',
-  flexDirection: 'column',
-}));
 
 export default function ProfileSection({ isEditMode, onEditModeChange }: ProfileSectionProps) {
   const { form, validationState, updateValidation, resetValidation } = useMypageForm();
@@ -73,38 +66,32 @@ export default function ProfileSection({ isEditMode, onEditModeChange }: Profile
         </Typography>
       </Divider>
 
-      <Stack
-        component='section'
-        direction={{ xs: 'column', md: 'row' }}
-        spacing={{ xs: 1, sm: 2, md: 4 }}
-      >
-        <FormGrid>
+      <BaseModal
+        isOpen={nicknameShowModal}
+        onClose={() => setNicknameShowModal(false)}
+        title='닉네임 중복 확인'
+        subtitle={modalMessage}
+        footer={
+          <Button onClick={() => setNicknameShowModal(false)} variant='contained' type='button'>
+            확인
+          </Button>
+        }
+      />
+
+      <Stack direction={{ xs: 'column', sm: 'row' }} spacing={2} sx={{ width: '100%' }}>
+        <FormControl fullWidth>
           <FormLabel htmlFor='name'>이름</FormLabel>
           <TextField
             {...register('name')}
             autoComplete='name'
             fullWidth
             id='name'
-            name='name'
-            type='name'
-            size='medium'
+            placeholder='홍길동'
             disabled
           />
-        </FormGrid>
+        </FormControl>
 
-        <BaseModal
-          isOpen={nicknameShowModal}
-          onClose={() => setNicknameShowModal(false)}
-          title='닉네임 중복 확인'
-          subtitle={modalMessage}
-          footer={
-            <Button onClick={() => setNicknameShowModal(false)} variant='contained' type='button'>
-              확인
-            </Button>
-          }
-        />
-
-        <FormGrid>
+        <FormControl fullWidth>
           <FormLabel htmlFor='nickname'>닉네임</FormLabel>
           <Stack direction='row' spacing={1}>
             <TextField
@@ -114,11 +101,8 @@ export default function ProfileSection({ isEditMode, onEditModeChange }: Profile
               disabled={!isEditMode}
               id='nickname'
               placeholder='동해번쩍 서해번쩍'
-              name='nickname'
-              type='name'
               fullWidth
-              autoComplete='name'
-              size='medium'
+              color={errors.nickname ? 'error' : 'primary'}
             />
             <Button
               variant='contained'
@@ -131,49 +115,49 @@ export default function ProfileSection({ isEditMode, onEditModeChange }: Profile
               중복확인
             </Button>
           </Stack>
-        </FormGrid>
+        </FormControl>
+      </Stack>
 
-        <FormGrid size={{ xs: 12 }}>
-          <FormLabel>성별</FormLabel>
+      <Stack direction={{ xs: 'column', sm: 'row' }} spacing={2} sx={{ width: '100%' }}>
+        <FormControl sx={{ flex: 1 }}>
+          <FormLabel htmlFor='gender'>성별</FormLabel>
           <Controller
             name='gender'
             control={control}
             render={({ field }) => (
-              <RadioGroup row {...field}>
-                <FormControlLabel
-                  value='W'
-                  label='여성'
-                  control={<Radio disabled={!isEditMode} />}
-                />
+              <RadioGroup {...field} row css={{ justifyContent: 'space-around' }}>
                 <FormControlLabel
                   value='M'
-                  label='남성'
                   control={<Radio disabled={!isEditMode} />}
+                  label='남자'
+                />
+                <FormControlLabel
+                  value='W'
+                  control={<Radio disabled={!isEditMode} />}
+                  label='여자'
                 />
               </RadioGroup>
             )}
           />
-        </FormGrid>
+        </FormControl>
 
-        <FormGrid flex={1}>
-          <FormControl>
-            <FormLabel htmlFor='age_group'>연령대</FormLabel>
-            <Controller
-              name='age_group'
-              control={control}
-              render={({ field }) => (
-                <Select {...field} disabled={!isEditMode} id='age_group'>
-                  <MenuItem value={'10'}>10대</MenuItem>
-                  <MenuItem value={'20'}>20대</MenuItem>
-                  <MenuItem value={'30'}>30대</MenuItem>
-                  <MenuItem value={'40'}>40대</MenuItem>
-                  <MenuItem value={'50'}>50대</MenuItem>
-                  <MenuItem value={'60'}>60대</MenuItem>
-                </Select>
-              )}
-            />
-          </FormControl>
-        </FormGrid>
+        <FormControl sx={{ flex: 1 }}>
+          <FormLabel htmlFor='age_group'>연령대</FormLabel>
+          <Controller
+            name='age_group'
+            control={control}
+            render={({ field }) => (
+              <Select {...field} disabled={!isEditMode} id='age_group'>
+                <MenuItem value={'10'}>10대</MenuItem>
+                <MenuItem value={'20'}>20대</MenuItem>
+                <MenuItem value={'30'}>30대</MenuItem>
+                <MenuItem value={'40'}>40대</MenuItem>
+                <MenuItem value={'50'}>50대</MenuItem>
+                <MenuItem value={'60'}>60대</MenuItem>
+              </Select>
+            )}
+          />
+        </FormControl>
       </Stack>
     </Stack>
   );

--- a/src/features/mypage/components/ProfileSection.tsx
+++ b/src/features/mypage/components/ProfileSection.tsx
@@ -17,11 +17,15 @@ import { useState } from 'react';
 import { Controller } from 'react-hook-form';
 import BaseModal from '../../../components/Modal/BaseModal';
 import { useNicknameValidateMutation } from '../../auth/hooks/useNicknameValidateMutation';
-import { useMypageForm } from '../hooks/useMypageForm';
 import { ProfileSectionProps } from '../types/mypage.types';
 
-export default function ProfileSection({ isEditMode, onEditModeChange }: ProfileSectionProps) {
-  const { form, validationState, updateValidation, resetValidation } = useMypageForm();
+export default function ProfileSection({
+  isEditMode,
+  onEditModeChange,
+  form,
+  validationState,
+  updateValidation,
+}: ProfileSectionProps) {
   const {
     register,
     control,

--- a/src/features/mypage/types/mypage.types.ts
+++ b/src/features/mypage/types/mypage.types.ts
@@ -12,10 +12,6 @@ export interface ProfileSectionProps {
   updateValidation: (key: keyof ValidationState, value: boolean) => void;
 }
 
-export interface EmailSectionProps {
-  isEditMode: boolean;
-}
-
 // eslint-disable-next-line @typescript-eslint/no-empty-object-type
 export interface PasswordSectionProps {
   // 독립적으로 동작하므로 props 불필요

--- a/src/features/mypage/types/mypage.types.ts
+++ b/src/features/mypage/types/mypage.types.ts
@@ -1,9 +1,15 @@
 // features/mypage/types/mypage.types.ts
 
+import { UseFormReturn } from 'react-hook-form';
+import { MyPageFormData } from '../../auth/types/zodTypes';
+
 // 섹션별 Props 타입
 export interface ProfileSectionProps {
   isEditMode: boolean;
   onEditModeChange: (mode: boolean) => void;
+  form: UseFormReturn<MyPageFormData>;
+  validationState: ValidationState;
+  updateValidation: (key: keyof ValidationState, value: boolean) => void;
 }
 
 export interface EmailSectionProps {

--- a/src/main.tsx
+++ b/src/main.tsx
@@ -34,14 +34,6 @@ const theme = createTheme({
       main: '#1F3A89',
     },
   },
-  components: {
-    MuiTextField: {
-      defaultProps: { size: 'small' },
-    },
-    MuiSelect: {
-      defaultProps: { size: 'small' },
-    },
-  },
 });
 
 enableMocking().then(() => {

--- a/src/main.tsx
+++ b/src/main.tsx
@@ -34,6 +34,14 @@ const theme = createTheme({
       main: '#1F3A89',
     },
   },
+  components: {
+    MuiTextField: {
+      defaultProps: { size: 'small' },
+    },
+    MuiSelect: {
+      defaultProps: { size: 'small' },
+    },
+  },
 });
 
 enableMocking().then(() => {

--- a/src/pages/Mypage.tsx
+++ b/src/pages/Mypage.tsx
@@ -17,7 +17,15 @@ export default function Mypage() {
   const [modalTitle, setModalTitle] = useState('');
   const navigate = useNavigate();
 
-  const { form, handleProfileSubmit, resetValidation, isLoading, error } = useMypageForm();
+  const {
+    form,
+    handleProfileSubmit,
+    resetValidation,
+    validationState,
+    updateValidation,
+    isLoading,
+    error,
+  } = useMypageForm();
 
   // 로딩 중일 때
   if (isLoading) {
@@ -29,33 +37,23 @@ export default function Mypage() {
     return <div>에러 발생</div>;
   }
 
-  const onSubmit = form.handleSubmit(
-    (data) => {
-      console.log('🚀 onSubmit 호출됨');
-      console.log('📋 폼 데이터:', data);
-      handleProfileSubmit(
-        data,
-        () => {
-          setModalTitle('회원정보 수정');
-          setModalMessage('마이페이지 수정 완료');
-          setShowModal(true);
-          setIsEditMode(false);
-        },
-        (message) => {
-          setModalTitle('회원정보 수정 오류');
-          setModalMessage(message);
-          setShowModal(true);
-        }
-      );
-    },
-    (errors) => {
-      console.error('❌ 폼 유효성 검사 실패:', errors);
-      console.log('현재 폼 값:', form.getValues());
-      console.log('에러 상세:', JSON.stringify(errors, null, 2));
-    }
-  );
+  const onSubmit = form.handleSubmit((data) => {
+    handleProfileSubmit(
+      data,
+      () => {
+        setModalTitle('회원정보 수정');
+        setModalMessage('마이페이지 수정 완료');
+        setShowModal(true);
+        setIsEditMode(false);
+      },
+      (message) => {
+        setModalTitle('회원정보 수정 오류');
+        setModalMessage(message);
+        setShowModal(true);
+      }
+    );
+  });
   const handleDelete = () => {
-    console.log('UserDelegte');
     navigate('/signup');
   };
   return (
@@ -131,7 +129,13 @@ export default function Mypage() {
           </Box>
 
           {/* 회원정보 섹션 */}
-          <ProfileSection isEditMode={isEditMode} onEditModeChange={setIsEditMode} />
+          <ProfileSection
+            isEditMode={isEditMode}
+            onEditModeChange={setIsEditMode}
+            form={form}
+            validationState={validationState}
+            updateValidation={updateValidation}
+          />
 
           {/* 이메일 변경 섹션 */}
           <EmailSection isEditMode={isEditMode} />
@@ -160,6 +164,8 @@ export default function Mypage() {
 
         {/* 즐겨찾는 지역 섹션 */}
         <FavoriteLocationSection />
+
+        {/* 회원탈퇴 */}
         <Divider sx={{ my: 4 }} />
         <Stack sx={{ alignItems: 'end' }}>
           <Button

--- a/src/pages/Mypage.tsx
+++ b/src/pages/Mypage.tsx
@@ -138,7 +138,13 @@ export default function Mypage() {
           />
 
           {/* 이메일 변경 섹션 */}
-          <EmailSection isEditMode={isEditMode} />
+          <EmailSection
+            isEditMode={isEditMode}
+            onEditModeChange={setIsEditMode}
+            form={form}
+            validationState={validationState}
+            updateValidation={updateValidation}
+          />
 
           {/* 모달 */}
           <BaseModal

--- a/src/pages/auth/SignUp.tsx
+++ b/src/pages/auth/SignUp.tsx
@@ -47,7 +47,6 @@ export default function SignUp() {
 
   //회원가입 버튼 클릭하면?mutation 불러서 비동기 통신해야함.
   const onSubmit: SubmitHandler<FormField> = (data) => {
-    //🎃confirm비밀번호와 emailCode는 제외해야함 -> 구조분해 할당
     const { passwordConfirm, emailCode, ...rest } = data;
     signUpMutation.mutate(rest, {
       onSuccess: () => {
@@ -257,12 +256,12 @@ export default function SignUp() {
               />
             </FormControl>
             <FormControl sx={{ flex: 1 }}>
-              <FormLabel htmlFor='named-select'>연령대</FormLabel>
+              <FormLabel htmlFor='age_group'>연령대</FormLabel>
               <Controller
                 name='age_group'
                 control={control}
                 render={({ field }) => (
-                  <Select {...field} id='named-select'>
+                  <Select {...field} id='age_group'>
                     <MenuItem value={'10'}>10대</MenuItem>
                     <MenuItem value={'20'}>20대</MenuItem>
                     <MenuItem value={'30'}>30대</MenuItem>
@@ -302,6 +301,34 @@ export default function SignUp() {
               </Button>
             </Stack>
           </FormControl>
+
+          {isEmailVerified ? (
+            <FormControl>
+              <FormLabel htmlFor='emailCode'>이메일 인증코드</FormLabel>
+              <TextField
+                {...register('emailCode')}
+                error={!!errors.emailCode}
+                helperText={errors.emailCode?.message}
+                fullWidth
+                id='emailCode'
+                placeholder='123456'
+                variant='outlined'
+                disabled={isEmailCodeChecked}
+              />
+              <Button
+                variant='contained'
+                color='success'
+                type='button'
+                onClick={handleEmailCodeValidate}
+                disabled={isEmailCodeChecked}
+              >
+                인증코드 확인
+              </Button>
+            </FormControl>
+          ) : (
+            // eslint-disable-next-line react/jsx-no-useless-fragment
+            <></>
+          )}
 
           <Stack
             direction={{ xs: 'column', sm: 'row' }}
@@ -343,33 +370,7 @@ export default function SignUp() {
               />
             </FormControl>
           </Stack>
-          {isEmailVerified ? (
-            <FormControl>
-              <FormLabel htmlFor='emailCode'>이메일 인증코드</FormLabel>
-              <TextField
-                {...register('emailCode')}
-                error={!!errors.emailCode}
-                helperText={errors.emailCode?.message}
-                fullWidth
-                id='emailCode'
-                placeholder='123456'
-                variant='outlined'
-                disabled={isEmailCodeChecked}
-              />
-              <Button
-                variant='contained'
-                color='success'
-                type='button'
-                onClick={handleEmailCodeValidate}
-                disabled={isEmailCodeChecked}
-              >
-                인증코드 확인
-              </Button>
-            </FormControl>
-          ) : (
-            // eslint-disable-next-line react/jsx-no-useless-fragment
-            <></>
-          )}
+
           <BaseModal
             isOpen={emailShowModal}
             onClose={() => setEmailShowModal(false)}

--- a/src/pages/auth/SignUp.tsx
+++ b/src/pages/auth/SignUp.tsx
@@ -189,44 +189,52 @@ export default function SignUp() {
           sx={{ display: 'flex', flexDirection: 'column', gap: 4 }}
           onSubmit={handleSubmit(onSubmit)}
         >
-          <FormControl fullWidth>
-            <FormLabel htmlFor='name'>이름</FormLabel>
-            <TextField
-              {...register('name')}
-              error={!!errors.name}
-              helperText={errors.name?.message}
-              autoComplete='name'
-              fullWidth
-              id='name'
-              placeholder='홍길동'
-              color={errors.name ? 'error' : 'primary'}
-            />
-          </FormControl>
-          <FormControl fullWidth>
-            <FormLabel htmlFor='nickname'>닉네임</FormLabel>
-            <Stack direction='row' spacing={1}>
+          <Stack
+            direction={{ xs: 'column', sm: 'row' }}
+            spacing={2}
+            sx={{
+              width: '100%',
+            }}
+          >
+            <FormControl fullWidth>
+              <FormLabel htmlFor='name'>이름</FormLabel>
               <TextField
-                {...register('nickname')}
-                error={!!errors.nickname}
-                helperText={errors.nickname?.message}
+                {...register('name')}
+                error={!!errors.name}
+                helperText={errors.name?.message}
+                autoComplete='name'
                 fullWidth
-                id='nickname'
-                placeholder='동해번쩍 서해번쩍'
-                color={errors.nickname ? 'error' : 'primary'}
-                disabled={isNicknameValidated} // 추가
+                id='name'
+                placeholder='홍길동'
+                color={errors.name ? 'error' : 'primary'}
               />
-              <Button
-                variant='contained'
-                color='info'
-                onClick={handleNicknameValidate}
-                disabled={isNicknameValidated}
-                type='button'
-                sx={{ minWidth: 'fit-content', whiteSpace: 'nowrap' }}
-              >
-                중복확인
-              </Button>
-            </Stack>
-          </FormControl>
+            </FormControl>
+            <FormControl fullWidth>
+              <FormLabel htmlFor='nickname'>닉네임</FormLabel>
+              <Stack direction='row' spacing={1}>
+                <TextField
+                  {...register('nickname')}
+                  error={!!errors.nickname}
+                  helperText={errors.nickname?.message}
+                  fullWidth
+                  id='nickname'
+                  placeholder='동해번쩍 서해번쩍'
+                  color={errors.nickname ? 'error' : 'primary'}
+                  disabled={isNicknameValidated} // 추가
+                />
+                <Button
+                  variant='contained'
+                  color='info'
+                  onClick={handleNicknameValidate}
+                  disabled={isNicknameValidated}
+                  type='button'
+                  sx={{ minWidth: 'fit-content', whiteSpace: 'nowrap' }}
+                >
+                  중복확인
+                </Button>
+              </Stack>
+            </FormControl>
+          </Stack>
 
           <Stack
             direction={{ xs: 'column', sm: 'row' }}
@@ -269,29 +277,72 @@ export default function SignUp() {
 
           <FormControl>
             <FormLabel htmlFor='email'>이메일</FormLabel>
-            <TextField
-              {...register('email')}
-              disabled={isEmailVerified}
-              fullWidth
-              id='email'
-              placeholder='your@email.com'
-              autoComplete='email'
-              variant='outlined'
-              error={!!errors.email}
-              helperText={errors.email?.message}
-              color={errors.email ? 'error' : 'primary'}
-            />
-            <Button
-              variant='contained'
-              color='success'
-              type='button'
-              onClick={handleEmailValidate}
-              disabled={isEmailVerified}
-            >
-              인증코드 보내기
-            </Button>
+            <Stack direction={{ xs: 'column', sm: 'row' }} spacing={{ xs: 1, sm: 4 }}>
+              <TextField
+                {...register('email')}
+                disabled={isEmailVerified}
+                id='email'
+                placeholder='your@email.com'
+                autoComplete='email'
+                variant='outlined'
+                error={!!errors.email}
+                fullWidth
+                helperText={errors.email?.message}
+                color={errors.email ? 'error' : 'primary'}
+              />
+              <Button
+                variant='contained'
+                color='success'
+                type='button'
+                onClick={handleEmailValidate}
+                disabled={isEmailVerified}
+                sx={{ minWidth: 'fit-content', whiteSpace: 'nowrap' }}
+              >
+                인증확인
+              </Button>
+            </Stack>
           </FormControl>
 
+          <Stack
+            direction={{ xs: 'column', sm: 'row' }}
+            spacing={2}
+            sx={{
+              width: '100%',
+            }}
+          >
+            <FormControl fullWidth>
+              <FormLabel htmlFor='password'>비밀번호</FormLabel>
+              <TextField
+                {...register('password')}
+                error={!!errors.password}
+                helperText={errors.password?.message}
+                required
+                fullWidth
+                placeholder='••••••'
+                type='password'
+                id='password'
+                autoComplete='new-password'
+                variant='outlined'
+                color={errors.password ? 'error' : 'primary'}
+              />
+            </FormControl>
+            <FormControl fullWidth>
+              <FormLabel htmlFor='passwordConfirm'>비밀번호 확인</FormLabel>
+              <TextField
+                {...register('passwordConfirm')}
+                error={!!errors.passwordConfirm}
+                helperText={errors.passwordConfirm?.message}
+                required
+                fullWidth
+                placeholder='••••••'
+                type='password'
+                id='passwordConfirm'
+                autoComplete='new-password'
+                variant='outlined'
+                color={errors.passwordConfirm ? 'error' : 'primary'}
+              />
+            </FormControl>
+          </Stack>
           {isEmailVerified ? (
             <FormControl>
               <FormLabel htmlFor='emailCode'>이메일 인증코드</FormLabel>
@@ -337,38 +388,6 @@ export default function SignUp() {
             }
           />
 
-          <FormControl>
-            <FormLabel htmlFor='password'>비밀번호</FormLabel>
-            <TextField
-              {...register('password')}
-              error={!!errors.password}
-              helperText={errors.password?.message}
-              required
-              fullWidth
-              placeholder='••••••'
-              type='password'
-              id='password'
-              autoComplete='new-password'
-              variant='outlined'
-              color={errors.password ? 'error' : 'primary'}
-            />
-          </FormControl>
-          <FormControl>
-            <FormLabel htmlFor='passwordConfirm'>비밀번호 확인</FormLabel>
-            <TextField
-              {...register('passwordConfirm')} // 이게 name, onChange 등을 자동으로 추가
-              error={!!errors.passwordConfirm}
-              helperText={errors.passwordConfirm?.message}
-              required
-              fullWidth
-              placeholder='••••••'
-              type='password'
-              id='passwordConfirm'
-              autoComplete='new-password'
-              variant='outlined'
-              color={errors.passwordConfirm ? 'error' : 'primary'}
-            />
-          </FormControl>
           <Button
             type='submit'
             fullWidth
@@ -383,15 +402,17 @@ export default function SignUp() {
           <Typography sx={{ color: 'text.secondary' }}>or</Typography>
         </Divider>
         <Box sx={{ display: 'flex', flexDirection: 'column', gap: 2 }}>
-          <GoogleButton fullWidth onClick={() => alert('Sign in with Google')}>
-            구글 로그인
-          </GoogleButton>
-          <KakaoButton fullWidth onClick={() => alert('Sign in with 카카오')}>
-            카카오 로그인
-          </KakaoButton>
-          <NaverButton fullWidth onClick={() => alert('Sign in with 네이버')}>
-            네이버 로그인
-          </NaverButton>
+          <Stack direction={{ xs: 'column', sm: 'row' }} spacing={{ xs: 1, sm: 2, md: 4 }}>
+            <GoogleButton fullWidth onClick={() => alert('Sign in with Google')}>
+              구글 로그인
+            </GoogleButton>
+            <KakaoButton fullWidth onClick={() => alert('Sign in with 카카오')}>
+              카카오 로그인
+            </KakaoButton>
+            <NaverButton fullWidth onClick={() => alert('Sign in with 네이버')}>
+              네이버 로그인
+            </NaverButton>
+          </Stack>
           <Typography sx={{ textAlign: 'center' }}>
             이미 계정이 있으신가요?{' '}
             <Link href='/login' variant='body2' sx={{ alignSelf: 'center' }}>

--- a/src/styles/AuthStyle.tsx
+++ b/src/styles/AuthStyle.tsx
@@ -16,7 +16,7 @@ export const CardMui = styled(MuiCard)(({ theme }) => ({
   boxShadow:
     'hsla(220, 30%, 5%, 0.05) 0px 5px 15px 0px, hsla(220, 25%, 10%, 0.05) 0px 15px 35px -5px',
   [theme.breakpoints.up('md')]: {
-    width: '960px',
+    width: '640px',
   },
 }));
 
@@ -24,6 +24,6 @@ export const ContainerMui = styled(Stack)(({ theme }) => ({
   padding: theme.spacing(2),
   fontFamily: 'Pretendard',
   [theme.breakpoints.up('md')]: {
-    padding: theme.spacing(4),
+    padding: theme.spacing(2),
   },
 }));


### PR DESCRIPTION
<!-- PR제목은 브랜치명과 동일하게 
예시 ) Chore/3 dev env set
-->
## 🔍 관련 이슈<!-- 이 PR과 관련된 이슈를 링크해주세요 -->

Resolves #123

## 📝 변경 사항

### 1. 마이페이지 - 이메일 중복 검증 추가
**파일**: `src/features/mypage/components/EmailSection.tsx`

현재 사용 중인 이메일과 동일한 이메일로 변경을 시도할 때 불필요한 API 요청을 방지하도록 개선했습니다.

**구현 내용**:
- `formState.defaultValues`를 통해 현재 사용자의 이메일 정보에 접근
- "인증코드 보내기" 버튼 클릭 시, 입력된 이메일과 현재 이메일을 비교
- 동일한 경우 모달로 경고 메시지를 표시하고 API 요청을 중단

```typescript
const handleEmailValidate = async () => {
  const email = watch('email') as string;
  const currentEmail = defaultValues?.email as string;

  // 현재 이메일과 동일한지 확인
  if (email === currentEmail) {
    setModalTitle('이메일 변경');
    setModalMessage('현재 사용 중인 이메일과 동일합니다. 새로운 이메일을 입력해주세요.');
    setShowModal(true);
    return; // API 요청 중단
  }
  // ... 기존 로직
};
```

### 2. 즐겨찾기 지역 - 서버 저장 기능 추가
사용자가 모달에서 선택한 지역을 서버에 저장하도록 구현했습니다. 

구현 내용:

- useFavoriteLocations 훅에서 addFavorite mutation 가져오기
- handleModalSave 함수에서 선택된 지역 데이터를 서버로 전송
- React Query가 자동으로 캐시를 갱신하여 UI 업데이트

**Before:**
```tsx
const handleModalSave = (data) => {
  setModalOpen(false);
  console.log(data); // 콘솔에만 출력
};
```

**After:**
```tsx

const handleModalSave = (data: { city: string; district: string }) => {
  addFavorite({
    city: data.city,
    district: data.district,
    alias: `${data.city} ${data.district}`, // 기본 alias 설정
  });
  setModalOpen(false);
};
```

**장점:**
✅ 전역 상태 관리 불필요 (서버가 단일 진실 공급원)
✅ React Query의 자동 캐시 갱신으로 UI 즉시 업데이트
✅ 새로고침 후에도 데이터 유지
✅ 다른 기기에서도 동기화


### 3. 즐겨찾기 카드 - UI 개선
파일:
```
src/features/location/components/FavoriteLocationSection.tsx
src/features/location/components/FavoriteLocationCard.tsx
```

**레이아웃 변경:**

- 3열 그리드 → 2x2 그리드로 변경 (MAX_FAVORITES: 3 → 4)
- 모바일(768px 이하)에서는 1열로 반응형 적용

**카드 스타일 개선:**

- padding: 16px → 24px (내부 여백 증가)
- width: 100% 추가 (그리드 셀 전체 너비 사용)
- minHeight: 60px 추가 (일관된 카드 높이 유지)

### 🎯 테스트 시나리오

- [ ] 이메일 중복 검증
- [ ] 마이페이지 접속
- [ ] 이메일 편집 모드 활성화
- [ ] 현재 이메일과 동일한 이메일 입력
- [ ] "인증코드 보내기" 버튼 클릭
- [ ] ✅ 경고 모달 표시 확인, API 요청 미발생 확인 (Network 탭)
- [ ] 즐겨찾기 지역 추가
- [ ] 마이페이지 > 즐겨찾는 지역 섹션
- [ ] "+" 버튼 클릭하여 모달 열기
- [ ] 시/도 및 구/군 선택
- [ ] 저장 버튼 클릭
- [ ] ✅ 새 카드가 즉시 화면에 표시되는지 확인
- [ ] ✅ 새로고침 후에도 데이터 유지 확인

## 📸 스크린샷<!-- UI 변경사항이 있다면 스크린샷을 첨부해주세요 -->

## 💬 리뷰 요청사항<!-- 리뷰어가 특별히 확인해주었으면 하는 부분 -->

---

**🙏 감사합니다!**
